### PR TITLE
Remove deprecated guava function in config (#2327)

### DIFF
--- a/config/src/main/java/net/md_5/bungee/config/Configuration.java
+++ b/config/src/main/java/net/md_5/bungee/config/Configuration.java
@@ -1,10 +1,10 @@
 package net.md_5.bungee.config;
 
-import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -143,7 +143,7 @@ public final class Configuration
      */
     public Collection<String> getKeys()
     {
-        return Sets.newLinkedHashSet( self.keySet() );
+        return new LinkedHashSet<>( self.keySet() );
     }
 
     /*------------------------------------------------------------------------*/


### PR DESCRIPTION
This removes the need to shade in the full guava library if a java program only uses bungeecord-config.